### PR TITLE
bug: replace yarn with npm for running tests and installing dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "create-8004-agent",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "create-8004-agent",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "license": "MIT",
             "dependencies": {
                 "@solana/web3.js": "^1.98.0",
@@ -2192,7 +2192,6 @@
             "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.1",
@@ -3050,18 +3049,6 @@
                 "encoding": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/node-gyp-build": {
-            "version": "4.8.4",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-            "license": "MIT",
-            "optional": true,
-            "bin": {
-                "node-gyp-build": "bin.js",
-                "node-gyp-build-optional": "optional.js",
-                "node-gyp-build-test": "build-test.js"
             }
         },
         "node_modules/object-assign": {
@@ -4002,7 +3989,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -4088,7 +4074,6 @@
             "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -4746,7 +4731,6 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
             "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -4781,7 +4765,6 @@
             "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/tests/e2e-a2a-client.ts
+++ b/tests/e2e-a2a-client.ts
@@ -9,7 +9,7 @@
  * 4. Start A2A server
  * 5. Test all client commands
  *
- * Run: yarn test:e2e
+ * Run: npm test:e2e
  */
 
 import { generateProject } from "../dist/generator.js";
@@ -133,7 +133,7 @@ async function main() {
     console.log("\n📦 Phase 2: Install Dependencies\n");
 
     await test("Install dependencies", () => {
-        execSync("yarn install --ignore-engines --silent 2>/dev/null", {
+        execSync("npm install --ignore-engines --silent 2>/dev/null", {
             cwd: TEST_DIR,
             stdio: "pipe",
             timeout: 120000,

--- a/tests/utils/chain-test-factory.ts
+++ b/tests/utils/chain-test-factory.ts
@@ -30,6 +30,14 @@ export interface ChainTestConfig {
     isTestnet?: boolean; // For informational purposes
 }
 
+// agent0-sdk doesn't support Monad yet, so Monad uses direct viem contract
+// calls instead. This means registration tests need different assertions
+// (no SDK, no registerIPFS, no setTrust, no OASF section in README).
+// See: src/templates/monad.ts
+function isMonadChain(chainKey: string): boolean {
+    return chainKey === 'monad-mainnet' || chainKey === 'monad-testnet';
+}
+
 /**
  * Create a complete test suite for a chain
  */
@@ -274,13 +282,20 @@ export function createChainTestSuite(config: ChainTestConfig) {
                     features: ['a2a', 'mcp'],
                     projectName: `${config.chainKey}-registration`,
                 });
-                
+
                 expect(await fileExists(projectDir, 'src/register.ts')).toBe(true);
-                
+
                 const registerCode = await readGeneratedFile(projectDir, 'src/register.ts');
-                expect(registerCode).toContain('agent0-sdk');
-                expect(registerCode).toContain('registerIPFS');
-                expect(registerCode).toContain(config.chainKey.includes('mainnet') ? 'chainId: ' : 'chainId: ');
+                if (isMonadChain(config.chainKey)) {
+                    // Monad uses direct viem contract calls instead of agent0-sdk
+                    expect(registerCode).toContain('viem');
+                    expect(registerCode).toContain('uploadToIPFS');
+                    expect(registerCode).toContain('defineChain');
+                } else {
+                    expect(registerCode).toContain('agent0-sdk');
+                    expect(registerCode).toContain('registerIPFS');
+                    expect(registerCode).toContain('chainId');
+                }
             });
 
             it('should have correct chain configuration', async () => {
@@ -289,12 +304,18 @@ export function createChainTestSuite(config: ChainTestConfig) {
                     features: ['a2a'],
                     projectName: `${config.chainKey}-chain-config`,
                 });
-                
+
                 const registerCode = await readGeneratedFile(projectDir, 'src/register.ts');
-                
-                // Verify SDK is initialized with correct chain
-                expect(registerCode).toContain('SDK');
-                expect(registerCode).toContain('chainId');
+
+                if (isMonadChain(config.chainKey)) {
+                    // Monad uses viem's defineChain with direct contract interaction
+                    expect(registerCode).toContain('defineChain');
+                    expect(registerCode).toContain('IDENTITY_REGISTRY');
+                } else {
+                    // Other chains use Agent0 SDK
+                    expect(registerCode).toContain('SDK');
+                    expect(registerCode).toContain('chainId');
+                }
             });
 
             it('should have correct trust models', async () => {
@@ -303,9 +324,14 @@ export function createChainTestSuite(config: ChainTestConfig) {
                     features: ['a2a'],
                     projectName: `${config.chainKey}-trust`,
                 });
-                
+
                 const registerCode = await readGeneratedFile(projectDir, 'src/register.ts');
-                expect(registerCode).toContain('setTrust');
+                if (isMonadChain(config.chainKey)) {
+                    // Monad stores trust models in metadata
+                    expect(registerCode).toContain('supportedTrust');
+                } else {
+                    expect(registerCode).toContain('setTrust');
+                }
             });
         });
 
@@ -516,23 +542,25 @@ export function createChainTestSuite(config: ChainTestConfig) {
                     features: ['a2a', 'mcp'],
                     projectName: `${config.chainKey}-readme`,
                 });
-                
+
                 const readme = await readGeneratedFile(projectDir, 'README.md');
-                
+
                 // Should have quick start section
                 expect(readme).toContain('Quick Start');
                 expect(readme).toContain('Configure environment');
                 expect(readme).toContain('PINATA_JWT');
                 expect(readme).toContain('OPENAI_API_KEY');
-                
+
                 // Should have chain-specific funding info
                 expect(readme).toContain('Fund your wallet');
-                
+
                 // Should mention registration
                 expect(readme).toContain('npm run register');
-                
-                // Should have OASF info
-                expect(readme).toContain('OASF');
+
+                // OASF section is only in SDK-based chains (not Monad)
+                if (!isMonadChain(config.chainKey)) {
+                    expect(readme).toContain('OASF');
+                }
             });
 
             it('should include correct chain name in README', async () => {


### PR DESCRIPTION
## Summary

- Added a GitHub Actions CI workflow (`test.yml`) to run the full test suite on push/PR to `main` across Node 18, 20, and 22
- Fixed failing Monad chain tests in `chain-test-factory.ts` , the `agent0-sdk` doesn't support Monad yet, so Monad templates use direct `viem` contract calls instead of the SDK. The test assertions were assuming SDK-based registration for all chains

## What changed

### `.github/workflows/test.yml` (new)
Runs `npm ci` → `npm run build` → `npm test` on every push and PR to `main`. Tests against Node 18, 20, and 22 via matrix strategy.

### `tests/utils/chain-test-factory.ts`
The generic test assertions assumed all chains use `agent0-sdk` (`registerIPFS`, `SDK`, `setTrust`, `OASF`). Monad chains use direct `viem` contract interaction instead, so the following assertions were updated for Monad:

| Test | SDK chains | Monad chains |
|------|-----------|--------------|
| Registration script | `agent0-sdk`, `registerIPFS` | `viem`, `uploadToIPFS`, `defineChain` |
| Chain configuration | `SDK`, `chainId` | `defineChain`, `IDENTITY_REGISTRY` |
| Trust models | `setTrust` | `supportedTrust` (in metadata) |
| README | expects `OASF` section | skipped (not in Monad template) |

## Notes

- **GitHub Actions free tier**: The CI workflow runs 3 jobs per trigger (one per Node version). The test suite takes ~5 min per run. Keep this in mind if the repo is on the free tier to avoid burning through the monthly quota. We can keep just one version if it sounds good for you all, we only have to decide which version.
- **Monad SDK support**: Once `agent0-sdk` adds Monad support, the Monad templates (`src/templates/monad.ts`) and corresponding test branches can be updated to use the SDK like other chains
- **Lint & format**: There are unused imports flagged by TypeScript (`validateRegistrationFile`, `cleanupTestOutput` in `chain-test-factory.ts`). Adding ESLint + Prettier to the CI pipeline would help catch these and keep the codebase consistent. I can add it on this PR or just leave it for someone else.

## Test plan

- [x] All 190 tests pass locally (`npm test`)
- [x] Verified workflow runs correctly with `act` (local GitHub Actions runner)
- [ ] Verify CI passes on GitHub after push
